### PR TITLE
add queryPlanner opt to explain

### DIFF
--- a/session.go
+++ b/session.go
@@ -3179,7 +3179,7 @@ func prepareFindOp(socket *mongoSocket, op *queryOp, limit int32) bool {
 	op.hasOptions = false
 
 	if explain {
-		op.query = bson.D{{"explain", op.query}}
+		op.query = bson.D{{"explain", op.query}, {"verbosity", "queryPlanner"}}
 		return false
 	}
 	return true


### PR DESCRIPTION
This PR sets explain()'s verbosity to `queryPlanner`.
To be replaced when official mgo adds a parameter.

@potocnyj PTAL