### PR TITLE
Relax required wire version to 3 for explains

### DIFF
--- a/session.go
+++ b/session.go
@@ -3139,7 +3139,11 @@ func (q *Query) One(result interface{}) (err error) {
 // It returns whether to expect a find command result or not. Note op may be
 // translated into an explain command, in which case the function returns false.
 func prepareFindOp(socket *mongoSocket, op *queryOp, limit int32) bool {
-	if socket.ServerInfo().MaxWireVersion < 4 || op.collection == "admin.$cmd" {
+	if op.collection == "admin.$cmd" {
+		return false
+	}
+	if wireVer := socket.ServerInfo().MaxWireVersion; wireVer < 3 ||
+		(wireVer == 3 && !op.options.Explain) {
 		return false
 	}
 


### PR DESCRIPTION
This PR lowers required wire protocol version to 3 [was 4] for explains.

That makes our proprietary software work down to at least MongoDB 3.0.0 [was: 3.2].

@ElPeque PTAL

